### PR TITLE
Load env once in app and simplify env helpers

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 func main() {
+	_ = godotenv.Load(".env")
 	configs := getConfigs()
 
 	connectionString, err := cmd.MakeConnectionString(
@@ -64,7 +65,6 @@ func getConfigs() cmd.Config {
 }
 
 func getEnv(key string) string {
-	_ = godotenv.Load(".env")
 	val := os.Getenv(key)
 	if val == "" {
 		log.Fatalf("Missing env var: %s", key)
@@ -73,7 +73,6 @@ func getEnv(key string) string {
 }
 
 func getEnvInt(key string) int {
-	_ = godotenv.Load(".env")
 	val := os.Getenv(key)
 	if val == "" {
 		log.Fatalf("Missing env var: %s", key)


### PR DESCRIPTION
## Summary
- load `.env` once on startup
- simplify env helper functions to just read variables

## Testing
- `go test ./...` *(fails: connection refused to database)*

------
https://chatgpt.com/codex/tasks/task_e_688d3fa4fdf88327a91db2a72ba6ea57