### PR TITLE
feat: add logging to event publisher

### DIFF
--- a/internal/core/ports/event_publisher.go
+++ b/internal/core/ports/event_publisher.go
@@ -2,6 +2,8 @@ package ports
 
 import (
 	"context"
+	"log/slog"
+
 	"quest-manager/internal/pkg/ddd"
 )
 
@@ -15,16 +17,20 @@ type EventPublisher interface {
 type NullEventPublisher struct{}
 
 func (p *NullEventPublisher) Publish(ctx context.Context, events ...ddd.DomainEvent) error {
-	// В production здесь была бы интеграция с message broker (RabbitMQ, Kafka и т.д.)
-	// Пока что просто логируем события
+	// In production, integrate with a message broker (RabbitMQ, Kafka, etc.)
+	// For now, just log the events
 	for _, event := range events {
-		// TODO: добавить структурированное логирование
-		_ = event
+		slog.InfoContext(ctx, "publishing domain event",
+			slog.String("event_name", event.GetName()),
+			slog.String("event_id", event.GetID().String()),
+		)
 	}
 	return nil
 }
 
 func (p *NullEventPublisher) PublishAsync(ctx context.Context, events ...ddd.DomainEvent) {
-	// Асинхронная версия - просто вызываем синхронную
-	_ = p.Publish(ctx, events...)
+	// Asynchronous version - simply call the synchronous one
+	if err := p.Publish(ctx, events...); err != nil {
+		slog.ErrorContext(ctx, "failed to publish domain events", slog.Any("error", err))
+	}
 }


### PR DESCRIPTION
## Summary
- add structured logging for domain events
- log errors in asynchronous publish
- translate event publisher comments to English

## Testing
- `go test ./internal/core/ports` (fails: Get "https://proxy.golang.org/github.com/google/uuid/@v/v1.6.0.zip": Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_688d46b574dc8327b915283af83c3334