### PR TITLE
Handle unit of work begin errors

### DIFF
--- a/internal/adapters/out/postgres/eventrepo/repository.go
+++ b/internal/adapters/out/postgres/eventrepo/repository.go
@@ -94,7 +94,9 @@ func (r *Repository) publishWithTracker(ctx context.Context, tracker ports.Track
 
 	isInTransaction := tracker.InTx()
 	if !isInTransaction {
-		tracker.Begin(ctx)
+		if err := tracker.Begin(ctx); err != nil {
+			return errs.WrapInfrastructureError("failed to begin event transaction", err)
+		}
 	}
 	tx := tracker.Tx()
 

--- a/internal/adapters/out/postgres/locationrepo/repository.go
+++ b/internal/adapters/out/postgres/locationrepo/repository.go
@@ -30,7 +30,9 @@ func (r *Repository) Save(ctx context.Context, l *location.Location) error {
 
 	isInTransaction := r.tracker.InTx()
 	if !isInTransaction {
-		r.tracker.Begin(ctx)
+		if err := r.tracker.Begin(ctx); err != nil {
+			return errs.WrapInfrastructureError("failed to begin location transaction", err)
+		}
 	}
 	tx := r.tracker.Tx()
 

--- a/internal/adapters/out/postgres/questrepo/repository.go
+++ b/internal/adapters/out/postgres/questrepo/repository.go
@@ -30,7 +30,9 @@ func (r *Repository) Save(ctx context.Context, q quest.Quest) error {
 
 	isInTransaction := r.tracker.InTx()
 	if !isInTransaction {
-		r.tracker.Begin(ctx)
+		if err := r.tracker.Begin(ctx); err != nil {
+			return errs.WrapInfrastructureError("failed to begin quest transaction", err)
+		}
 	}
 	tx := r.tracker.Tx()
 

--- a/internal/adapters/out/postgres/unit_of_work.go
+++ b/internal/adapters/out/postgres/unit_of_work.go
@@ -53,8 +53,13 @@ func (u *UnitOfWork) InTx() bool {
 	return u.tx != nil
 }
 
-func (u *UnitOfWork) Begin(ctx context.Context) {
-	u.tx = u.db.WithContext(ctx).Begin()
+func (u *UnitOfWork) Begin(ctx context.Context) error {
+	tx := u.db.WithContext(ctx).Begin()
+	if tx.Error != nil {
+		return tx.Error
+	}
+	u.tx = tx
+	return nil
 }
 
 func (u *UnitOfWork) Rollback() error {

--- a/internal/core/application/usecases/commands/assign_quest_status_handler.go
+++ b/internal/core/application/usecases/commands/assign_quest_status_handler.go
@@ -31,7 +31,9 @@ func NewAssignQuestCommandHandler(unitOfWork ports.UnitOfWork, eventPublisher po
 // Handle assigns a quest to a user using domain business rules.
 func (h *assignQuestHandler) Handle(ctx context.Context, cmd AssignQuestCommand) (AssignQuestResult, error) {
 	// Begin transaction
-	h.unitOfWork.Begin(ctx)
+	if err := h.unitOfWork.Begin(ctx); err != nil {
+		return AssignQuestResult{}, errs.WrapInfrastructureError("failed to begin quest assignment transaction", err)
+	}
 
 	// Get quest - if not found → 404
 	q, err := h.unitOfWork.QuestRepository().GetByID(ctx, cmd.ID)

--- a/internal/core/application/usecases/commands/change_quest_status_handler.go
+++ b/internal/core/application/usecases/commands/change_quest_status_handler.go
@@ -34,7 +34,9 @@ func (h *changeQuestStatusHandler) Handle(ctx context.Context, cmd ChangeQuestSt
 	}
 
 	// Begin transaction
-	h.unitOfWork.Begin(ctx)
+	if err := h.unitOfWork.Begin(ctx); err != nil {
+		return ChangeQuestStatusResult{}, errs.WrapInfrastructureError("failed to begin quest status change transaction", err)
+	}
 
 	// Get quest - if not found → 404
 	q, err := h.unitOfWork.QuestRepository().GetByID(ctx, cmd.QuestID)

--- a/internal/core/application/usecases/commands/create_quest_handler.go
+++ b/internal/core/application/usecases/commands/create_quest_handler.go
@@ -36,7 +36,9 @@ func (h *createQuestHandler) Handle(ctx context.Context, cmd CreateQuestCommand)
 	var executionLocationID *uuid.UUID
 
 	// Begin transaction
-	h.unitOfWork.Begin(ctx)
+	if err := h.unitOfWork.Begin(ctx); err != nil {
+		return quest.Quest{}, errs.WrapInfrastructureError("failed to begin quest creation transaction", err)
+	}
 
 	// Create or find target location
 	targetLoc, err := location.NewLocation(

--- a/internal/core/ports/tracker.go
+++ b/internal/core/ports/tracker.go
@@ -9,7 +9,7 @@ type Tracker interface {
 	Tx() *gorm.DB
 	Db() *gorm.DB
 	InTx() bool
-	Begin(ctx context.Context)
+	Begin(ctx context.Context) error
 	Commit(ctx context.Context) error
 	Rollback() error
 }

--- a/internal/core/ports/unit_of_work.go
+++ b/internal/core/ports/unit_of_work.go
@@ -5,7 +5,7 @@ import (
 )
 
 type UnitOfWork interface {
-	Begin(ctx context.Context)
+	Begin(ctx context.Context) error
 	Commit(ctx context.Context) error
 	Rollback() error
 	QuestRepository() QuestRepository


### PR DESCRIPTION
## Summary
- Return errors from unit of work Begin and verify transaction start failure
- Propagate error-returning Begin through tracker and unit of work interfaces
- Handle begin errors across repositories and use cases

## Testing
- `go test ./...` *(fails: dial tcp [::1]:5432: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688d4a75e3548327aac1dff196d9ce18