### PR TITLE
feat: add active wait for event processing

### DIFF
--- a/tests/integration/cases/default.go
+++ b/tests/integration/cases/default.go
@@ -45,5 +45,5 @@ func (s *DefaultSuite) SetupTest() {
 // TearDownTest cleans state after each test
 func (s *DefaultSuite) TearDownTest() {
 	// Wait for event processing completion
-	s.TestDIContainer.WaitForEventProcessing()
+	s.TestDIContainer.WaitForEventProcessing(0)
 }


### PR DESCRIPTION
## Summary
- poll event storage until expected events are stored to avoid flakiness
- ensure test suite waits for event processing completion

## Testing
- `go test ./...` *(fails: dial tcp [::1]:5432: connect: connection refused)*
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e4e45d2c08327bbcf5731d4f0eb50