### PR TITLE
feat: make quest generator deterministic

### DIFF
--- a/tests/integration/core/test_data_generators/quest_generator.go
+++ b/tests/integration/core/test_data_generators/quest_generator.go
@@ -3,11 +3,24 @@ package testdatagenerators
 import (
 	"fmt"
 	"math/rand"
-	"time"
+	"os"
+	"strconv"
 
 	"quest-manager/internal/core/domain/model/kernel"
 	"quest-manager/internal/generated/servers"
 )
+
+var questRand *rand.Rand
+
+func init() {
+	seed := int64(1)
+	if s, ok := os.LookupEnv("QUEST_GENERATOR_SEED"); ok {
+		if parsed, err := strconv.ParseInt(s, 10, 64); err == nil {
+			seed = parsed
+		}
+	}
+	questRand = rand.New(rand.NewSource(seed))
+}
 
 // QuestTestData содержит данные для создания тестового квеста
 type QuestTestData struct {
@@ -55,7 +68,7 @@ func DefaultQuestData() QuestTestData {
 
 // RandomQuestData генерирует случайные данные для квеста
 func RandomQuestData() *servers.CreateQuestRequest {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r := questRand
 
 	difficulties := []servers.CreateQuestRequestDifficulty{
 		servers.CreateQuestRequestDifficultyEasy,


### PR DESCRIPTION
## Summary
- seed quest generator randomness using `QUEST_GENERATOR_SEED` env var
- reuse package-level `*rand.Rand` across generator calls for reproducible tests

## Testing
- `go test ./...` *(fails: Ошибка создания БД: dial tcp [::1]:5432: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688e794e81908327985e35c5aaf7a712