### PR TITLE
Fix assigned quests test to compare created and returned quests

### DIFF
--- a/tests/integration/cases/quest_handler/list_assigned_quests_test.go
+++ b/tests/integration/cases/quest_handler/list_assigned_quests_test.go
@@ -18,7 +18,6 @@ func (s *Suite) TestListAssignedQuests() {
 	s.Require().NoError(err)
 
 	// Assign all created quests to the test user
-	var assignedQuests []quest.Quest
 	for _, q := range createdQuests {
 		_, err := casesteps.AssignQuestStep(ctx, s.TestDIContainer.AssignQuestHandler, q.ID(), testUserID)
 		s.Require().NoError(err)
@@ -31,7 +30,7 @@ func (s *Suite) TestListAssignedQuests() {
 	s.Require().NoError(err)
 	listAssertions := assertions.NewQuestListAssertions(s.Assert())
 	listAssertions.QuestsHaveMinimumCount(quests, expectedCount)
-	listAssertions.QuestsContainAllCreated(assignedQuests, quests)
+	listAssertions.QuestsContainAllCreated(createdQuests, quests)
 
 	// Verify all returned quests are assigned to the correct user
 	for _, q := range quests {


### PR DESCRIPTION
## Summary
- ensure `ListAssignedQuests` test verifies all created quests are returned

## Testing
- `go test ./tests/integration/cases/quest_handler -count=1` *(fails: dial tcp [::1]:5432: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688e79626c4c832799ce36fb921ec522