### PR TITLE
refactor quest list tests to table-driven

### DIFF
--- a/tests/integration/cases/quest_handler/list_quests_test.go
+++ b/tests/integration/cases/quest_handler/list_quests_test.go
@@ -11,95 +11,94 @@ import (
 func (s *Suite) TestListQuests() {
 	ctx := context.Background()
 
-	// Arrange - create multiple quests
-	expectedCount := 2
-	createdQuests, err := casesteps.CreateMultipleRandomQuests(ctx, s.TestDIContainer.CreateQuestHandler, expectedCount)
-	s.Require().NoError(err)
+	testCases := []struct {
+		desc    string
+		prepare func() ([]quest.Quest, error)
+		status  *quest.Status
+		assert  func(created []quest.Quest, quests []quest.Quest, err error)
+	}{
+		{
+			desc:   "list quests",
+			status: nil,
+			prepare: func() ([]quest.Quest, error) {
+				expectedCount := 2
+				return casesteps.CreateMultipleRandomQuests(ctx, s.TestDIContainer.CreateQuestHandler, expectedCount)
+			},
+			assert: func(created []quest.Quest, quests []quest.Quest, err error) {
+				s.Require().NoError(err)
+				listAssertions := assertions.NewQuestListAssertions(s.Assert())
+				listAssertions.QuestsHaveMinimumCount(quests, len(created))
+				listAssertions.QuestsContainAllCreated(created, quests)
+			},
+		},
+		{
+			desc:   "list quests empty database",
+			status: nil,
+			prepare: func() ([]quest.Quest, error) {
+				return []quest.Quest{}, nil
+			},
+			assert: func(created []quest.Quest, quests []quest.Quest, err error) {
+				s.Require().NoError(err)
+				s.Assert().Len(quests, 0)
+			},
+		},
+		{
+			desc:   "list quests with valid status",
+			status: func() *quest.Status { st := quest.StatusPosted; return &st }(),
+			prepare: func() ([]quest.Quest, error) {
+				expectedCount := 3
+				created, err := casesteps.CreateMultipleRandomQuests(ctx, s.TestDIContainer.CreateQuestHandler, expectedCount)
+				if err != nil {
+					return nil, err
+				}
+				targetStatus := quest.StatusPosted
+				_, err = casesteps.ChangeQuestStatusStep(ctx, s.TestDIContainer.ChangeQuestStatusHandler,
+					s.TestDIContainer.QuestRepository, created[0].ID(), targetStatus)
+				return created, err
+			},
+			assert: func(created []quest.Quest, quests []quest.Quest, err error) {
+				s.Require().NoError(err)
+				s.Assert().GreaterOrEqual(len(quests), 1, "Should have at least one quest with StatusPosted")
+				listAssertions := assertions.NewQuestListAssertions(s.Assert())
+				listAssertions.QuestsAllHaveStatus(quests, quest.StatusPosted)
+				listAssertions.QuestWithIDExists(quests, created[0].ID().String())
+			},
+		},
+		{
+			desc:   "list quests with empty status",
+			status: nil,
+			prepare: func() ([]quest.Quest, error) {
+				expectedCount := 2
+				return casesteps.CreateMultipleRandomQuests(ctx, s.TestDIContainer.CreateQuestHandler, expectedCount)
+			},
+			assert: func(created []quest.Quest, quests []quest.Quest, err error) {
+				s.Require().NoError(err)
+				listAssertions := assertions.NewQuestListAssertions(s.Assert())
+				listAssertions.QuestsHaveMinimumCount(quests, len(created))
+				listAssertions.QuestsContainAllCreated(created, quests)
+			},
+		},
+		{
+			desc:   "list quests with invalid status",
+			status: func() *quest.Status { st := quest.Status("invalid_status_that_does_not_exist"); return &st }(),
+			prepare: func() ([]quest.Quest, error) {
+				_, err := casesteps.CreateRandomQuestStep(ctx, s.TestDIContainer.CreateQuestHandler)
+				return nil, err
+			},
+			assert: func(created []quest.Quest, quests []quest.Quest, err error) {
+				s.Require().Error(err, "Should return validation error for invalid status")
+				s.Assert().Contains(err.Error(), "must be one of", "Error should mention valid status values")
+				s.Assert().Nil(quests, "Quests should be nil when there's a validation error")
+			},
+		},
+	}
 
-	// Act - get list of quests (all quests, without status filter)
-	quests, err := casesteps.ListQuestsStep(ctx, s.TestDIContainer.ListQuestsHandler, nil)
-
-	// Assert
-	s.Require().NoError(err)
-
-	// Create assertions for list verification
-	listAssertions := assertions.NewQuestListAssertions(s.Assert())
-	listAssertions.QuestsHaveMinimumCount(quests, expectedCount)
-	listAssertions.QuestsContainAllCreated(createdQuests, quests)
-}
-
-func (s *Suite) TestListQuestsEmpty() {
-	ctx := context.Background()
-
-	// Act - get list of quests from empty database
-	quests, err := casesteps.ListQuestsStep(ctx, s.TestDIContainer.ListQuestsHandler, nil)
-
-	// Assert
-	s.Require().NoError(err)
-	s.Assert().Len(quests, 0)
-}
-
-func (s *Suite) TestListQuestsWithValidStatus() {
-	ctx := context.Background()
-
-	// Arrange - create multiple quests
-	expectedCount := 3
-	createdQuests, err := casesteps.CreateMultipleRandomQuests(ctx, s.TestDIContainer.CreateQuestHandler, expectedCount)
-	s.Require().NoError(err)
-
-	// Change quest status for filtering test
-	targetStatus := quest.StatusPosted
-	_, err = casesteps.ChangeQuestStatusStep(ctx, s.TestDIContainer.ChangeQuestStatusHandler,
-		s.TestDIContainer.QuestRepository, createdQuests[0].ID(), targetStatus)
-	s.Require().NoError(err)
-
-	// Leave other quests with default StatusCreated status
-
-	// Act - get list of quests filtered by StatusPosted
-	quests, err := casesteps.ListQuestsStep(ctx, s.TestDIContainer.ListQuestsHandler, &targetStatus)
-
-	// Assert
-	s.Require().NoError(err)
-	s.Assert().GreaterOrEqual(len(quests), 1, "Should have at least one quest with StatusPosted")
-
-	listAssertions := assertions.NewQuestListAssertions(s.Assert())
-	listAssertions.QuestsAllHaveStatus(quests, targetStatus)
-	listAssertions.QuestWithIDExists(quests, createdQuests[0].ID().String())
-}
-
-func (s *Suite) TestListQuestsWithEmptyStatus() {
-	ctx := context.Background()
-
-	// Arrange - create multiple quests
-	expectedCount := 2
-	createdQuests, err := casesteps.CreateMultipleRandomQuests(ctx, s.TestDIContainer.CreateQuestHandler, expectedCount)
-	s.Require().NoError(err)
-
-	// Act - get list of quests without status filter (nil)
-	quests, err := casesteps.ListQuestsStep(ctx, s.TestDIContainer.ListQuestsHandler, nil)
-
-	// Assert
-	s.Require().NoError(err)
-
-	// Create assertions for list verification
-	listAssertions := assertions.NewQuestListAssertions(s.Assert())
-	listAssertions.QuestsHaveMinimumCount(quests, expectedCount)
-	listAssertions.QuestsContainAllCreated(createdQuests, quests)
-}
-
-func (s *Suite) TestListQuestsWithInvalidStatus() {
-	ctx := context.Background()
-
-	// Arrange - create quest to ensure database is not empty
-	_, err := casesteps.CreateRandomQuestStep(ctx, s.TestDIContainer.CreateQuestHandler)
-	s.Require().NoError(err)
-
-	// Act - try to get list of quests with invalid status
-	invalidStatus := quest.Status("invalid_status_that_does_not_exist")
-	quests, err := casesteps.ListQuestsStep(ctx, s.TestDIContainer.ListQuestsHandler, &invalidStatus)
-
-	// Assert - should return validation error
-	s.Require().Error(err, "Should return validation error for invalid status")
-	s.Assert().Contains(err.Error(), "must be one of", "Error should mention valid status values")
-	s.Assert().Nil(quests, "Quests should be nil when there's a validation error")
+	for _, tc := range testCases {
+		s.Run(tc.desc, func() {
+			created, err := tc.prepare()
+			s.Require().NoError(err)
+			quests, err := casesteps.ListQuestsStep(ctx, s.TestDIContainer.ListQuestsHandler, tc.status)
+			tc.assert(created, quests, err)
+		})
+	}
 }

--- a/tests/integration/cases/quest_http/list_quests_http_test.go
+++ b/tests/integration/cases/quest_http/list_quests_http_test.go
@@ -13,158 +13,132 @@ import (
 func (s *Suite) TestListQuestsHTTP() {
 	ctx := context.Background()
 
-	// Arrange - create multiple quests via handler (for setup)
-	expectedCount := 2
-	createdQuests, err := casesteps.CreateMultipleRandomQuests(ctx, s.TestDIContainer.CreateQuestHandler, expectedCount)
-	s.Require().NoError(err)
-
-	// Act - get list of quests via HTTP API (all quests, without status filter)
-	listReq := casesteps.ListQuestsHTTPRequest("")
-	listResp, err := casesteps.ExecuteHTTPRequest(ctx, s.TestDIContainer.HTTPRouter, listReq)
-
-	// Assert
-	s.Require().NoError(err)
-	s.Require().Equal(http.StatusOK, listResp.StatusCode)
-
-	// Parse response
-	var quests []servers.Quest
-	err = json.Unmarshal([]byte(listResp.Body), &quests)
-	s.Require().NoError(err)
-
-	// Verify response
-	s.Assert().GreaterOrEqual(len(quests), expectedCount, "Should return at least %d quests", expectedCount)
-
-	// Verify all created quests are in the response
-	returnedQuestIDs := make(map[string]bool)
-	for _, q := range quests {
-		returnedQuestIDs[q.Id] = true
+	testCases := []struct {
+		desc         string
+		prepare      func() ([]quest.Quest, error)
+		statusQuery  string
+		expectedCode int
+		assert       func(created []quest.Quest, resp *casesteps.HTTPResponse)
+	}{
+		{
+			desc:         "list quests HTTP",
+			statusQuery:  "",
+			expectedCode: http.StatusOK,
+			prepare: func() ([]quest.Quest, error) {
+				expectedCount := 2
+				return casesteps.CreateMultipleRandomQuests(ctx, s.TestDIContainer.CreateQuestHandler, expectedCount)
+			},
+			assert: func(created []quest.Quest, resp *casesteps.HTTPResponse) {
+				var quests []servers.Quest
+				err := json.Unmarshal([]byte(resp.Body), &quests)
+				s.Require().NoError(err)
+				s.Assert().GreaterOrEqual(len(quests), len(created), "Should return at least %d quests", len(created))
+				returnedQuestIDs := make(map[string]bool)
+				for _, q := range quests {
+					returnedQuestIDs[q.Id] = true
+				}
+				for _, createdQuest := range created {
+					questID := createdQuest.ID().String()
+					s.Assert().True(returnedQuestIDs[questID], "Created quest %s should be in quests list", questID)
+				}
+			},
+		},
+		{
+			desc:         "list quests HTTP empty",
+			statusQuery:  "",
+			expectedCode: http.StatusOK,
+			prepare: func() ([]quest.Quest, error) {
+				return []quest.Quest{}, nil
+			},
+			assert: func(created []quest.Quest, resp *casesteps.HTTPResponse) {
+				var quests []servers.Quest
+				err := json.Unmarshal([]byte(resp.Body), &quests)
+				s.Require().NoError(err)
+				s.Assert().Len(quests, 0, "Should return empty list when no quests exist")
+			},
+		},
+		{
+			desc:         "list quests HTTP with valid status",
+			statusQuery:  string(quest.StatusPosted),
+			expectedCode: http.StatusOK,
+			prepare: func() ([]quest.Quest, error) {
+				expectedCount := 3
+				created, err := casesteps.CreateMultipleRandomQuests(ctx, s.TestDIContainer.CreateQuestHandler, expectedCount)
+				if err != nil {
+					return nil, err
+				}
+				targetStatus := quest.StatusPosted
+				_, err = casesteps.ChangeQuestStatusStep(ctx, s.TestDIContainer.ChangeQuestStatusHandler,
+					s.TestDIContainer.QuestRepository, created[0].ID(), targetStatus)
+				return created, err
+			},
+			assert: func(created []quest.Quest, resp *casesteps.HTTPResponse) {
+				var quests []servers.Quest
+				err := json.Unmarshal([]byte(resp.Body), &quests)
+				s.Require().NoError(err)
+				s.Assert().GreaterOrEqual(len(quests), 1, "Should have at least one quest with StatusPosted")
+				for _, q := range quests {
+					s.Assert().Equal(string(quest.StatusPosted), string(q.Status), "All quests should have StatusPosted")
+				}
+				foundTargetQuest := false
+				targetQuestID := created[0].ID().String()
+				for _, q := range quests {
+					if q.Id == targetQuestID {
+						foundTargetQuest = true
+						break
+					}
+				}
+				s.Assert().True(foundTargetQuest, "Quest with StatusPosted should be in filtered list")
+			},
+		},
+		{
+			desc:         "list quests HTTP with empty status",
+			statusQuery:  "",
+			expectedCode: http.StatusOK,
+			prepare: func() ([]quest.Quest, error) {
+				expectedCount := 2
+				return casesteps.CreateMultipleRandomQuests(ctx, s.TestDIContainer.CreateQuestHandler, expectedCount)
+			},
+			assert: func(created []quest.Quest, resp *casesteps.HTTPResponse) {
+				var quests []servers.Quest
+				err := json.Unmarshal([]byte(resp.Body), &quests)
+				s.Require().NoError(err)
+				s.Assert().GreaterOrEqual(len(quests), len(created), "Should return at least %d quests", len(created))
+				returnedQuestIDs := make(map[string]bool)
+				for _, q := range quests {
+					returnedQuestIDs[q.Id] = true
+				}
+				for _, createdQuest := range created {
+					questID := createdQuest.ID().String()
+					s.Assert().True(returnedQuestIDs[questID], "Created quest %s should be in quests list", questID)
+				}
+			},
+		},
+		{
+			desc:         "list quests HTTP with invalid status",
+			statusQuery:  "invalid_status_that_does_not_exist",
+			expectedCode: http.StatusBadRequest,
+			prepare: func() ([]quest.Quest, error) {
+				_, err := casesteps.CreateRandomQuestStep(ctx, s.TestDIContainer.CreateQuestHandler)
+				return nil, err
+			},
+			assert: func(created []quest.Quest, resp *casesteps.HTTPResponse) {
+				s.Assert().Contains(resp.Body, "validation failed", "Error message should contain validation failure details")
+				s.Assert().Contains(resp.Body, "must be one of", "Error message should mention valid status values")
+			},
+		},
 	}
 
-	for _, createdQuest := range createdQuests {
-		questID := createdQuest.ID().String()
-		s.Assert().True(returnedQuestIDs[questID], "Created quest %s should be in quests list", questID)
+	for _, tc := range testCases {
+		s.Run(tc.desc, func() {
+			created, err := tc.prepare()
+			s.Require().NoError(err)
+
+			listReq := casesteps.ListQuestsHTTPRequest(tc.statusQuery)
+			listResp, err := casesteps.ExecuteHTTPRequest(ctx, s.TestDIContainer.HTTPRouter, listReq)
+			s.Require().NoError(err)
+			s.Require().Equal(tc.expectedCode, listResp.StatusCode)
+			tc.assert(created, listResp)
+		})
 	}
-}
-
-func (s *Suite) TestListQuestsHTTPEmpty() {
-	ctx := context.Background()
-
-	// Act - get list of quests from empty database via HTTP API
-	listReq := casesteps.ListQuestsHTTPRequest("")
-	listResp, err := casesteps.ExecuteHTTPRequest(ctx, s.TestDIContainer.HTTPRouter, listReq)
-
-	// Assert
-	s.Require().NoError(err)
-	s.Require().Equal(http.StatusOK, listResp.StatusCode)
-
-	// Parse response
-	var quests []servers.Quest
-	err = json.Unmarshal([]byte(listResp.Body), &quests)
-	s.Require().NoError(err)
-
-	s.Assert().Len(quests, 0, "Should return empty list when no quests exist")
-}
-
-func (s *Suite) TestListQuestsHTTPWithValidStatus() {
-	ctx := context.Background()
-
-	// Arrange - create multiple quests via handler
-	expectedCount := 3
-	createdQuests, err := casesteps.CreateMultipleRandomQuests(ctx, s.TestDIContainer.CreateQuestHandler, expectedCount)
-	s.Require().NoError(err)
-
-	// Change quest status for filtering test
-	targetStatus := quest.StatusPosted
-	_, err = casesteps.ChangeQuestStatusStep(ctx, s.TestDIContainer.ChangeQuestStatusHandler,
-		s.TestDIContainer.QuestRepository, createdQuests[0].ID(), targetStatus)
-	s.Require().NoError(err)
-
-	// Leave other quests with default StatusCreated status
-
-	// Act - get list of quests filtered by StatusPosted via HTTP API
-	listReq := casesteps.ListQuestsHTTPRequest(string(targetStatus))
-	listResp, err := casesteps.ExecuteHTTPRequest(ctx, s.TestDIContainer.HTTPRouter, listReq)
-
-	// Assert
-	s.Require().NoError(err)
-	s.Require().Equal(http.StatusOK, listResp.StatusCode)
-
-	// Parse response
-	var quests []servers.Quest
-	err = json.Unmarshal([]byte(listResp.Body), &quests)
-	s.Require().NoError(err)
-
-	s.Assert().GreaterOrEqual(len(quests), 1, "Should have at least one quest with StatusPosted")
-
-	// Verify all returned quests have the correct status
-	for _, q := range quests {
-		s.Assert().Equal(string(targetStatus), string(q.Status), "All quests should have StatusPosted")
-	}
-
-	// Verify our specific quest is in the list
-	foundTargetQuest := false
-	targetQuestID := createdQuests[0].ID().String()
-	for _, q := range quests {
-		if q.Id == targetQuestID {
-			foundTargetQuest = true
-			break
-		}
-	}
-	s.Assert().True(foundTargetQuest, "Quest with StatusPosted should be in filtered list")
-}
-
-func (s *Suite) TestListQuestsHTTPWithEmptyStatus() {
-	ctx := context.Background()
-
-	// Arrange - create multiple quests via handler
-	expectedCount := 2
-	createdQuests, err := casesteps.CreateMultipleRandomQuests(ctx, s.TestDIContainer.CreateQuestHandler, expectedCount)
-	s.Require().NoError(err)
-
-	// Act - get list of quests without status filter via HTTP API
-	listReq := casesteps.ListQuestsHTTPRequest("")
-	listResp, err := casesteps.ExecuteHTTPRequest(ctx, s.TestDIContainer.HTTPRouter, listReq)
-
-	// Assert
-	s.Require().NoError(err)
-	s.Require().Equal(http.StatusOK, listResp.StatusCode)
-
-	// Parse response
-	var quests []servers.Quest
-	err = json.Unmarshal([]byte(listResp.Body), &quests)
-	s.Require().NoError(err)
-
-	// Verify response
-	s.Assert().GreaterOrEqual(len(quests), expectedCount, "Should return at least %d quests", expectedCount)
-
-	// Verify all created quests are in the response
-	returnedQuestIDs := make(map[string]bool)
-	for _, q := range quests {
-		returnedQuestIDs[q.Id] = true
-	}
-
-	for _, createdQuest := range createdQuests {
-		questID := createdQuest.ID().String()
-		s.Assert().True(returnedQuestIDs[questID], "Created quest %s should be in quests list", questID)
-	}
-}
-
-func (s *Suite) TestListQuestsHTTPWithInvalidStatus() {
-	ctx := context.Background()
-
-	// Arrange - create quest to ensure database is not empty
-	_, err := casesteps.CreateRandomQuestStep(ctx, s.TestDIContainer.CreateQuestHandler)
-	s.Require().NoError(err)
-
-	// Act - try to get list of quests with invalid status via HTTP API
-	listReq := casesteps.ListQuestsHTTPRequest("invalid_status_that_does_not_exist")
-	listResp, err := casesteps.ExecuteHTTPRequest(ctx, s.TestDIContainer.HTTPRouter, listReq)
-
-	// Assert - should return 400 validation error
-	s.Require().NoError(err)
-	s.Require().Equal(http.StatusBadRequest, listResp.StatusCode, "Should return 400 for invalid status")
-
-	// Verify error message contains validation details
-	s.Assert().Contains(listResp.Body, "validation failed", "Error message should contain validation failure details")
-	s.Assert().Contains(listResp.Body, "must be one of", "Error message should mention valid status values")
 }


### PR DESCRIPTION
## Summary
- refactor quest handler list tests to table-driven
- refactor HTTP quest list tests to table-driven

## Testing
- `go test -tags=integration ./tests/integration/...` *(fails: dial tcp [::1]:5432: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688e79616ca4832792a6e283df81d102