### PR TITLE
refactor: consolidate quest assignment tests

### DIFF
--- a/tests/domain/assign_quest_test.go
+++ b/tests/domain/assign_quest_test.go
@@ -172,3 +172,18 @@ func TestQuest_AssignTo_MultipleAssignmentAttempts(t *testing.T) {
 	assert.Contains(t, err.Error(), "quest is already assigned to another user")
 	assert.Equal(t, firstUser, *q.Assignee, "Assignee should not change")
 }
+
+func TestQuest_AssignTo_AfterPostingViaChangeStatus(t *testing.T) {
+	q := createValidQuest(t)
+
+	// Post the quest using ChangeStatus to ensure proper transition
+	err := q.ChangeStatus(quest.StatusPosted)
+	assert.NoError(t, err)
+
+	userID := "post-change-user"
+	err = q.AssignTo(userID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, quest.StatusAssigned, q.Status)
+	assert.Equal(t, userID, *q.Assignee)
+}

--- a/tests/domain/quest_test.go
+++ b/tests/domain/quest_test.go
@@ -235,34 +235,6 @@ func TestNewQuest_ValidDurationBoundaries(t *testing.T) {
 	}
 }
 
-func TestQuest_AssignTo_Success(t *testing.T) {
-	q := createValidQuest(t)
-	userID := "test-user-123"
-
-	err := q.AssignTo(userID)
-
-	assert.NoError(t, err)
-	assert.Equal(t, quest.StatusAssigned, q.Status)
-	assert.NotNil(t, q.Assignee)
-	assert.Equal(t, userID, *q.Assignee)
-	assert.True(t, q.UpdatedAt.After(q.CreatedAt))
-}
-
-func TestQuest_AssignTo_FromPostedStatus(t *testing.T) {
-	q := createValidQuest(t)
-
-	// Change status to posted first
-	err := q.ChangeStatus(quest.StatusPosted)
-	assert.NoError(t, err)
-
-	userID := "test-user-123"
-	err = q.AssignTo(userID)
-
-	assert.NoError(t, err)
-	assert.Equal(t, quest.StatusAssigned, q.Status)
-	assert.Equal(t, userID, *q.Assignee)
-}
-
 // Helper function to create a valid quest for testing
 func createValidQuest(t *testing.T) *quest.Quest {
 	targetLocation := kernel.GeoCoordinate{Lat: 55.7558, Lon: 37.6176}


### PR DESCRIPTION
## Summary
- remove duplicate quest assignment tests from quest_test.go
- verify assignment after posting via change status in assign_quest_test.go

## Testing
- `go test ./tests/domain -run TestQuest_AssignTo_AfterPostingViaChangeStatus -v`
- `go test ./...` *(fails: connection refused to database)*

------
https://chatgpt.com/codex/tasks/task_e_68bafedef65883279b67d1d9133372ed