### PR TITLE
Inject time provider and remove sleeps in tests

### DIFF
--- a/internal/adapters/out/postgres/locationrepo/mappers.go
+++ b/internal/adapters/out/postgres/locationrepo/mappers.go
@@ -4,6 +4,7 @@ import (
 	"quest-manager/internal/core/domain/model/kernel"
 	"quest-manager/internal/core/domain/model/location"
 	"quest-manager/internal/pkg/ddd"
+	"quest-manager/internal/pkg/timeprovider"
 
 	"github.com/google/uuid"
 )
@@ -38,6 +39,7 @@ func DtoToDomain(dto LocationDTO) (*location.Location, error) {
 		Address:       dto.Address,
 		CreatedAt:     dto.CreatedAt,
 		UpdatedAt:     dto.UpdatedAt,
+		TimeProvider:  timeprovider.RealTimeProvider{},
 	}
 
 	return l, nil

--- a/internal/adapters/out/postgres/questrepo/mappers.go
+++ b/internal/adapters/out/postgres/questrepo/mappers.go
@@ -6,6 +6,7 @@ import (
 	"quest-manager/internal/core/domain/model/kernel"
 	"quest-manager/internal/core/domain/model/quest"
 	"quest-manager/internal/pkg/ddd"
+	"quest-manager/internal/pkg/timeprovider"
 
 	"github.com/google/uuid"
 )
@@ -126,6 +127,7 @@ func dtoToDomainCommon(dto QuestDTO, id uuid.UUID, targetCoord, execCoord kernel
 		Assignee:          dto.Assignee,
 		CreatedAt:         dto.CreatedAt,
 		UpdatedAt:         dto.UpdatedAt,
+		TimeProvider:      timeprovider.RealTimeProvider{},
 	}
 
 	// Опциональные ссылки на локации

--- a/internal/pkg/timeprovider/timeprovider.go
+++ b/internal/pkg/timeprovider/timeprovider.go
@@ -1,0 +1,31 @@
+package timeprovider
+
+import "time"
+
+// TimeProvider defines an interface for providing and advancing time.
+type TimeProvider interface {
+	Now() time.Time
+	Advance(d time.Duration)
+}
+
+// RealTimeProvider uses the system clock and real sleeping.
+type RealTimeProvider struct{}
+
+func (RealTimeProvider) Now() time.Time { return time.Now() }
+
+func (RealTimeProvider) Advance(d time.Duration) { time.Sleep(d) }
+
+// FakeTimeProvider allows manual control over time progression.
+type FakeTimeProvider struct {
+	current time.Time
+}
+
+// NewFake returns a FakeTimeProvider starting at the specified time.
+func NewFake(start time.Time) *FakeTimeProvider {
+	return &FakeTimeProvider{current: start}
+}
+
+func (f *FakeTimeProvider) Now() time.Time { return f.current }
+
+// Advance moves the internal clock forward by the specified duration.
+func (f *FakeTimeProvider) Advance(d time.Duration) { f.current = f.current.Add(d) }

--- a/tests/domain/location_test.go
+++ b/tests/domain/location_test.go
@@ -11,6 +11,7 @@ import (
 
 	"quest-manager/internal/core/domain/model/kernel"
 	"quest-manager/internal/core/domain/model/location"
+	"quest-manager/internal/pkg/timeprovider"
 )
 
 func TestNewLocation_Success(t *testing.T) {
@@ -97,8 +98,10 @@ func TestLocation_Update_Success(t *testing.T) {
 	// Clear domain events from creation
 	loc.ClearDomainEvents()
 
-	// Small delay to ensure UpdatedAt changes
-	time.Sleep(1 * time.Millisecond)
+	fakeTime := timeprovider.NewFake(loc.UpdatedAt)
+	loc.SetTimeProvider(fakeTime)
+
+	fakeTime.Advance(1 * time.Millisecond)
 
 	// Update location
 	newCoordinate := kernel.GeoCoordinate{Lat: 59.9311, Lon: 30.3609} // St. Petersburg
@@ -207,8 +210,10 @@ func TestLocation_TimestampBehavior(t *testing.T) {
 	// CreatedAt should equal UpdatedAt on creation
 	assert.Equal(t, createdAt, originalUpdatedAt, "CreatedAt should equal UpdatedAt on creation")
 
-	// Small delay to ensure time difference
-	time.Sleep(2 * time.Millisecond)
+	fakeTime := timeprovider.NewFake(loc.UpdatedAt)
+	loc.SetTimeProvider(fakeTime)
+
+	fakeTime.Advance(2 * time.Millisecond)
 
 	// Update location
 	newCoordinate := kernel.GeoCoordinate{Lat: 59.9311, Lon: 30.3609}

--- a/tests/domain/quest_status_test.go
+++ b/tests/domain/quest_status_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"quest-manager/internal/core/domain/model/quest"
+	"quest-manager/internal/pkg/timeprovider"
 )
 
 func TestIsValidStatus(t *testing.T) {
@@ -50,11 +51,12 @@ func TestQuest_ChangeStatus_ValidTransitions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			q := createValidQuest(t)
+			fakeTime := timeprovider.NewFake(q.UpdatedAt)
+			q.SetTimeProvider(fakeTime)
 			q.Status = tt.fromStatus
 			originalUpdatedAt := q.UpdatedAt
 
-			// Small delay to ensure UpdatedAt changes
-			time.Sleep(1 * time.Millisecond)
+			fakeTime.Advance(1 * time.Millisecond)
 
 			err := q.ChangeStatus(tt.toStatus)
 

--- a/tests/integration/tests/quest_e2e_tests/assign_quest_e2e_test.go
+++ b/tests/integration/tests/quest_e2e_tests/assign_quest_e2e_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"quest-manager/internal/core/domain/model/quest"
 	"quest-manager/internal/generated/servers"
@@ -34,7 +33,7 @@ func (s *E2ESuite) TestCreateThroughHandlerAssignThroughAPI() {
 	s.Require().NoError(err)
 
 	// Wait for async processing
-	time.Sleep(100 * time.Millisecond)
+	s.TestDIContainer.WaitForEventProcessing(0)
 
 	// 2. Assign quest through API using helper
 	userID := uuid.New().String()
@@ -50,7 +49,7 @@ func (s *E2ESuite) TestCreateThroughHandlerAssignThroughAPI() {
 	s.Require().NoError(err, "Should unmarshal assign response")
 
 	// Wait for async processing
-	time.Sleep(100 * time.Millisecond)
+	s.TestDIContainer.WaitForEventProcessing(0)
 
 	// 3. Verify database data is updated
 	updatedQuest, err := s.TestDIContainer.QuestRepository.GetByID(ctx, createdQuest.ID())

--- a/tests/integration/tests/quest_e2e_tests/create_quest_e2e_test.go
+++ b/tests/integration/tests/quest_e2e_tests/create_quest_e2e_test.go
@@ -2,7 +2,6 @@ package quest_e2e_tests
 
 import (
 	"context"
-	"time"
 
 	"quest-manager/internal/generated/servers"
 	"quest-manager/tests/integration/core/assertions"
@@ -93,7 +92,7 @@ func (s *E2ESuite) TestCreateQuestThroughAPIInvalidCoordinates() {
 	s.Assert().Equal(400, createResp.StatusCode, "Should return bad request for invalid coordinates")
 
 	// Wait for any async processing
-	time.Sleep(100 * time.Millisecond)
+	s.TestDIContainer.WaitForEventProcessing(0)
 
 	// 2. Verify quest table has no new records
 	finalQuests, err := s.TestDIContainer.QuestRepository.FindAll(ctx)

--- a/tests/integration/tests/repository_tests/event_repository_test.go
+++ b/tests/integration/tests/repository_tests/event_repository_test.go
@@ -11,6 +11,7 @@ import (
 
 	"quest-manager/internal/core/domain/model/quest"
 	"quest-manager/internal/pkg/ddd"
+	"quest-manager/internal/pkg/timeprovider"
 	teststorage "quest-manager/tests/integration/core/storage"
 
 	"github.com/google/uuid"
@@ -33,7 +34,7 @@ func (s *Suite) TestEventRepository_Publish_SingleEvent() {
 	s.Require().NoError(err)
 
 	// Verify event was stored (using our event storage helper)
-	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB)
+	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB, timeprovider.RealTimeProvider{})
 	events, err := eventStorage.GetEventsByType(ctx, "test.event")
 	s.Require().NoError(err)
 	s.Len(events, 1)
@@ -69,7 +70,7 @@ func (s *Suite) TestEventRepository_Publish_MultipleEvents() {
 	s.Require().NoError(err)
 
 	// Verify all events were stored
-	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB)
+	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB, timeprovider.RealTimeProvider{})
 
 	allEvents, err := eventStorage.GetEventsByAggregateID(ctx, aggregateID)
 	s.Require().NoError(err)
@@ -95,7 +96,7 @@ func (s *Suite) TestEventRepository_Publish_EmptyEvents() {
 	s.Require().NoError(err)
 
 	// Verify no events were stored
-	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB)
+	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB, timeprovider.RealTimeProvider{})
 	count, err := eventStorage.CountEvents(ctx)
 	s.Require().NoError(err)
 	s.Equal(int64(0), count)
@@ -120,7 +121,7 @@ func (s *Suite) TestEventRepository_Publish_WithTransaction() {
 	s.Require().NoError(err)
 
 	// Within transaction, events should be visible
-	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB)
+	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB, timeprovider.RealTimeProvider{})
 	events, err := eventStorage.GetEventsByType(ctx, "transaction.test")
 	s.Require().NoError(err)
 	s.Len(events, 2)
@@ -163,7 +164,7 @@ func (s *Suite) TestEventRepository_Publish_ComplexDomainScenario() {
 	s.Require().NoError(err)
 
 	// Assert - verify complete event sequence
-	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB)
+	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB, timeprovider.RealTimeProvider{})
 	questEvents, err := eventStorage.GetEventsByAggregateID(ctx, q.ID())
 	s.Require().NoError(err)
 	s.GreaterOrEqual(len(questEvents), 3) // At least 3 events
@@ -216,7 +217,7 @@ func (s *Suite) TestEventRepository_PostgreSQL_JSONEventData() {
 	s.Require().NoError(err)
 
 	// Assert - verify complex JSON is preserved
-	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB)
+	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB, timeprovider.RealTimeProvider{})
 	events, err := eventStorage.GetEventsByType(ctx, "complex.json.test")
 	s.Require().NoError(err)
 	s.Len(events, 1)
@@ -251,7 +252,7 @@ func (s *Suite) TestEventRepository_PostgreSQL_ConcurrentEventPublishing() {
 	s.Require().NoError(err2)
 
 	// Verify both events were stored correctly
-	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB)
+	eventStorage := teststorage.NewEventStorage(s.TestDIContainer.DB, timeprovider.RealTimeProvider{})
 	events, err := eventStorage.GetEventsByType(ctx, "concurrent.test")
 	s.Require().NoError(err)
 	s.Len(events, 2)


### PR DESCRIPTION
## Summary
- add time provider abstraction with real and fake implementations
- inject time provider into domain models and test utilities
- replace time.Sleep calls in tests with controlled time advancement

## Testing
- `go test ./...` *(fails: connection refused to [::1]:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf3b89c208327b25fe06b851c6647