### PR TITLE
Refactor unit of work lifecycle per request

### DIFF
--- a/internal/core/application/usecases/queries/get_quest_by_id.go
+++ b/internal/core/application/usecases/queries/get_quest_by_id.go
@@ -17,17 +17,22 @@ type GetQuestByIDQueryHandler interface {
 
 // getQuestByIDHandler is the implementation of GetQuestByIDQueryHandler.
 type getQuestByIDHandler struct {
-	repo ports.QuestRepository
+	unitOfWorkFactory ports.UnitOfWorkFactory
 }
 
 // NewGetQuestByIDQueryHandler creates a new GetQuestByIDQueryHandler instance.
-func NewGetQuestByIDQueryHandler(repo ports.QuestRepository) GetQuestByIDQueryHandler {
-	return &getQuestByIDHandler{repo: repo}
+func NewGetQuestByIDQueryHandler(factory ports.UnitOfWorkFactory) GetQuestByIDQueryHandler {
+	return &getQuestByIDHandler{unitOfWorkFactory: factory}
 }
 
 // Handle processes the query to fetch a quest by its unique ID.
 func (h *getQuestByIDHandler) Handle(ctx context.Context, questID uuid.UUID) (quest.Quest, error) {
-	q, err := h.repo.GetByID(ctx, questID)
+	unitOfWork, _, err := h.unitOfWorkFactory()
+	if err != nil {
+		return quest.Quest{}, errs.WrapInfrastructureError("failed to create unit of work for quest lookup", err)
+	}
+
+	q, err := unitOfWork.QuestRepository().GetByID(ctx, questID)
 	if err != nil {
 		// If quest not found, return NotFoundError for 404 response
 		return quest.Quest{}, errs.NewNotFoundErrorWithCause("quest", questID.String(), err)

--- a/internal/core/application/usecases/queries/list_assigned_quests.go
+++ b/internal/core/application/usecases/queries/list_assigned_quests.go
@@ -7,6 +7,7 @@ import (
 
 	"quest-manager/internal/core/domain/model/quest"
 	"quest-manager/internal/core/ports"
+	"quest-manager/internal/pkg/errs"
 )
 
 // ListAssignedQuestsQueryHandler defines the interface for handling assigned quests retrieval.
@@ -15,15 +16,20 @@ type ListAssignedQuestsQueryHandler interface {
 }
 
 type listAssignedQuestsHandler struct {
-	repo ports.QuestRepository
+	unitOfWorkFactory ports.UnitOfWorkFactory
 }
 
 // NewListAssignedQuestsQueryHandler creates a new instance of ListAssignedQuestsQueryHandler.
-func NewListAssignedQuestsQueryHandler(repo ports.QuestRepository) ListAssignedQuestsQueryHandler {
-	return &listAssignedQuestsHandler{repo: repo}
+func NewListAssignedQuestsQueryHandler(factory ports.UnitOfWorkFactory) ListAssignedQuestsQueryHandler {
+	return &listAssignedQuestsHandler{unitOfWorkFactory: factory}
 }
 
 // Handle retrieves all quests assigned to the given user.
 func (h *listAssignedQuestsHandler) Handle(ctx context.Context, userID uuid.UUID) ([]quest.Quest, error) {
-	return h.repo.FindByAssignee(ctx, userID)
+	unitOfWork, _, err := h.unitOfWorkFactory()
+	if err != nil {
+		return nil, errs.WrapInfrastructureError("failed to create unit of work for assigned quests lookup", err)
+	}
+
+	return unitOfWork.QuestRepository().FindByAssignee(ctx, userID)
 }

--- a/internal/core/ports/unit_of_work.go
+++ b/internal/core/ports/unit_of_work.go
@@ -11,3 +11,8 @@ type UnitOfWork interface {
 	QuestRepository() QuestRepository
 	LocationRepository() LocationRepository
 }
+
+// UnitOfWorkFactory creates a fresh UnitOfWork and an EventPublisher bound to the
+// same transactional tracker. Callers are responsible for managing the
+// transaction lifecycle (Begin/Commit/Rollback) for the returned UnitOfWork.
+type UnitOfWorkFactory func() (UnitOfWork, EventPublisher, error)

--- a/tests/contracts/mocks/contract_di_container.go
+++ b/tests/contracts/mocks/contract_di_container.go
@@ -16,6 +16,7 @@ type ContractDIContainer struct {
 	LocationRepository ports.LocationRepository
 	EventPublisher     ports.EventPublisher
 	UnitOfWork         ports.UnitOfWork
+	UnitOfWorkFactory  ports.UnitOfWorkFactory
 
 	// Command Handlers
 	CreateQuestHandler       commands.CreateQuestCommandHandler
@@ -37,22 +38,27 @@ func NewContractDIContainer() *ContractDIContainer {
 	eventPublisher := &MockEventPublisher{}
 	unitOfWork := NewMockUnitOfWork()
 
+	factory := func() (ports.UnitOfWork, ports.EventPublisher, error) {
+		return unitOfWork, eventPublisher, nil
+	}
+
 	// Create command handlers with mocked dependencies
-	createQuestHandler := commands.NewCreateQuestCommandHandler(unitOfWork, eventPublisher)
-	assignQuestHandler := commands.NewAssignQuestCommandHandler(unitOfWork, eventPublisher)
-	changeQuestStatusHandler := commands.NewChangeQuestStatusCommandHandler(unitOfWork, eventPublisher)
+	createQuestHandler := commands.NewCreateQuestCommandHandler(factory)
+	assignQuestHandler := commands.NewAssignQuestCommandHandler(factory)
+	changeQuestStatusHandler := commands.NewChangeQuestStatusCommandHandler(factory)
 
 	// Create query handlers with mocked dependencies
-	listQuestsHandler := queries.NewListQuestsQueryHandler(questRepo)
-	getQuestByIDHandler := queries.NewGetQuestByIDQueryHandler(questRepo)
-	searchQuestsByRadiusHandler := queries.NewSearchQuestsByRadiusQueryHandler(questRepo)
-	listAssignedQuestsHandler := queries.NewListAssignedQuestsQueryHandler(questRepo)
+	listQuestsHandler := queries.NewListQuestsQueryHandler(factory)
+	getQuestByIDHandler := queries.NewGetQuestByIDQueryHandler(factory)
+	searchQuestsByRadiusHandler := queries.NewSearchQuestsByRadiusQueryHandler(factory)
+	listAssignedQuestsHandler := queries.NewListAssignedQuestsQueryHandler(factory)
 
 	return &ContractDIContainer{
 		QuestRepository:    questRepo,
 		LocationRepository: locationRepo,
 		EventPublisher:     eventPublisher,
 		UnitOfWork:         unitOfWork,
+		UnitOfWorkFactory:  factory,
 
 		CreateQuestHandler:       createQuestHandler,
 		AssignQuestHandler:       assignQuestHandler,

--- a/tests/integration/tests/quest_handler_tests/concurrency_test.go
+++ b/tests/integration/tests/quest_handler_tests/concurrency_test.go
@@ -1,0 +1,58 @@
+package quest_handler_tests
+
+import (
+	"context"
+	"sync"
+
+	"quest-manager/internal/core/domain/model/quest"
+	casesteps "quest-manager/tests/integration/core/case_steps"
+	testdatagenerators "quest-manager/tests/integration/core/test_data_generators"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// TestCreateQuestHandlerParallelRequests ensures that each command execution
+// uses an independent transactional scope so parallel requests do not
+// interfere with each other.
+func (s *Suite) TestCreateQuestHandlerParallelRequests() {
+	ctx := context.Background()
+
+	questDataA := testdatagenerators.NewQuest(testdatagenerators.WithTitle("Parallel Quest A"))
+	questDataB := testdatagenerators.NewQuest(testdatagenerators.WithTitle("Parallel Quest B"))
+
+	quests := make([]quest.Quest, 0, 2)
+	var mu sync.Mutex
+
+	g := errgroup.Group{}
+	g.Go(func() error {
+		created, err := casesteps.CreateQuestStep(ctx, s.TestDIContainer.CreateQuestHandler, questDataA)
+		if err != nil {
+			return err
+		}
+		mu.Lock()
+		quests = append(quests, created)
+		mu.Unlock()
+		return nil
+	})
+
+	g.Go(func() error {
+		created, err := casesteps.CreateQuestStep(ctx, s.TestDIContainer.CreateQuestHandler, questDataB)
+		if err != nil {
+			return err
+		}
+		mu.Lock()
+		quests = append(quests, created)
+		mu.Unlock()
+		return nil
+	})
+
+	s.Require().NoError(g.Wait())
+	s.Require().Len(quests, 2)
+	s.Assert().NotEqual(quests[0].ID(), quests[1].ID(), "quests created in parallel should have unique IDs")
+
+	for _, createdQuest := range quests {
+		savedQuest, err := s.TestDIContainer.QuestRepository.GetByID(ctx, createdQuest.ID())
+		s.Require().NoError(err)
+		s.Assert().Equal(createdQuest.ID(), savedQuest.ID())
+	}
+}


### PR DESCRIPTION
## Summary
- provide a request-scoped unit of work factory in the composition root and update command/query handlers to create fresh transactional scopes
- adjust the PostgreSQL event publisher to work with per-request trackers and refresh test containers/mocks to use the new factory API
- add an integration test that exercises two concurrent quest creations to ensure transactions no longer conflict

## Testing
- go test ./... *(fails in this environment: requires PostgreSQL service)*

------
https://chatgpt.com/codex/tasks/task_e_68dce81df0808327bc84ce7d17bab173